### PR TITLE
fix: Fixed npm unable to install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-loading": "^2.0.3",
     "react-moment": "^0.8.4",
     "react-redux": "^6.0.1",
-    "react-router-dom": "^4.4.0",
+    "react-router-dom": "^5.0.1",
     "react-scripts": "^3.0.1",
     "react-share": "^3.0.0",
     "react-switch": "^4.1.0",


### PR DESCRIPTION
Fixed npm unable to install error due to depreciated react-router-dom package